### PR TITLE
Update Angular CLI version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OiNg
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 16.1.7.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.6.
 
 ## Development server
 


### PR DESCRIPTION
## Summary
- update Angular CLI version in README to 18.0.6

## Testing
- `npm test` *(fails: ng not found)*
- `npm install --omit=optional --no-progress` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6883da07a030832fb387ff5d1df328e2