### PR TITLE
Fix OTP backspace handler

### DIFF
--- a/src/app/auth-form/auth-form.component.html
+++ b/src/app/auth-form/auth-form.component.html
@@ -64,7 +64,7 @@
           type="text"
           [maxLength]="1"
           (input)="moveFocus(otp1, otp2)"
-          (keydown.backspace)="moveBack(otp1, otp2)"
+          (keydown.backspace)="moveBack(otp1, null)"
           autocomplete="one-time-code"
           class="bg-[#F3F3F3] text-xl w-12 py-3 rounded-xl focus:outline-slate-500 focus:outline-2 text-center mr-4"
         />


### PR DESCRIPTION
## Summary
- correct backspace behavior on first OTP input

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6883d9fccefc832fb43804bfc7fbe522